### PR TITLE
Fix reaction stats button not working on question page

### DIFF
--- a/src/DntSite.Web/Features/StackExchangeQuestions/Models/MarkAsAnswerAction.cs
+++ b/src/DntSite.Web/Features/StackExchangeQuestions/Models/MarkAsAnswerAction.cs
@@ -3,5 +3,7 @@ namespace DntSite.Web.Features.StackExchangeQuestions.Models;
 public enum MarkAsAnswerAction
 {
     ThumbsUp,
-    Cancel
+    Cancel,
+
+    ShowList
 }


### PR DESCRIPTION
The `مشاهده آمار واکنش‌ها` button is not functioning for some reason. Initially, I thought the multiple forms on the page might not have unique names, but that was not the case. Instead, it appears that Blazor was unable to pass `ReactionType.ShowList` as the button's value. However, setting the value to its equivalent number (-2) worked as expected.

I added a new `ShowList` property to the `MarkAsAnswerAction` enum to resolve the issue and now the button works as expected.